### PR TITLE
Updates the poms

### DIFF
--- a/nexus/pom.xml
+++ b/nexus/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.orbisgis</groupId>
     <artifactId>orbisgis-nexus</artifactId>
-    <version>1</version>
+    <version>2</version>
     <packaging>pom</packaging>
     <name>OrbisGIS Nexus Parent</name>
     <description>nexus.orbisgis.org repository</description>
@@ -19,11 +19,6 @@
         <developerConnection>scm:git:https://github.com/irstv/orbisgis-view-plugins.git</developerConnection>
         <url>git@github.com:irstv/orbisgis-view-plugins.git</url>
     </scm>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
     <developers>
         <developer>
             <name>Nicolas Fortin</name>
@@ -38,6 +33,17 @@
             <organization>IRSTV CNRS-FR-2488</organization>
         </developer>
     </developers>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <profiles>
         <profile>
             <id>orbisgis-release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>orbisgis-parents</artifactId>
     <name>OrbisGIS Parents</name>
     <packaging>pom</packaging>
-    <version>1</version>
+    <version>2</version>
     
     <modules>
         <module>nexus</module>


### PR DESCRIPTION
Updates the pom because the usage of the org.sonatype.oss.oss-parent as parent is deprecated.
So it adds to the nexus pom the distributionManagement.